### PR TITLE
added version information in the test report

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+import gymnasium
+import numpy as np
+import matplotlib
+
+def pytest_report_header():
+    """Print version information in the header of the test report."""
+    out_ =  f"------------------" + '\n' + \
+            f"gymnasium: {gymnasium.__version__}" + '\n' + \
+            f"numpy: {np.__version__}" + '\n' + \
+            f"matplotlib: {matplotlib.__version__}" + '\n' + \
+            f"------------------"
+    return out_


### PR DESCRIPTION
Now pytest report outputs version information of the gymnasium, numpy and matplotlib libraries. This is helpful to monitor the github action run-tests.yml